### PR TITLE
call bash as bash so [[ works

### DIFF
--- a/bin/chgems
+++ b/bin/chgems
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 case "$1" in
 	-h|--help)


### PR DESCRIPTION
Bash features are unavailable when bash is invoked as /bin/sh 
Alternative would be to make the script more sh compatible, but doubt that's necessary.
http://wiki.bash-hackers.org/scripting/bashbehaviour
