### PR TITLE
README: run ‘make install’ via sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
     wget -O chgems-0.3.2.tar.gz https://github.com/postmodern/chgems/archive/v0.3.2.tar.gz
     tar -xzvf chgems-0.3.2.tar.gz
     cd chgems-0.3.2/
-    make install
+    sudo make install
 
 ### PGP
 


### PR DESCRIPTION
A minor doc change – suggest running `make install` via `sudo` (this also matches chruby’s and ruby-install’s installation docs).
